### PR TITLE
Into<bool> for #name -> From<#name> for bool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,9 @@ pub fn yes_or_no(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
             }
         }
 
-        impl Into<bool> for #name {
-            fn into(self) -> bool {
-                self.yes()
+        impl From<#name> for bool {
+            fn from(opt: #name) -> Self {
+                opt.yes()
             }
         }
 


### PR DESCRIPTION
Generally in rust code it's preferred to implement From instead of Into.

https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into